### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/vendor/jquery/jquery.js
+++ b/vendor/jquery/jquery.js
@@ -5976,7 +5976,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/karam-ajaj/CV/security/code-scanning/3](https://github.com/karam-ajaj/CV/security/code-scanning/3)

In general, to fix this problem you must stop using a regex-based transformation that expands self-closing tags into open/close tag pairs on arbitrary HTML strings. Either remove the transformation or replace it with a safer implementation that does not attempt to interpret arbitrary HTML via regex and does not modify potentially sanitized content.

For this specific codebase, the best low-impact fix—aligned with how jQuery itself addressed this in later releases—is to change `jQuery.htmlPrefilter` so it simply returns the `html` string unchanged, removing the unsafe `replace` call while preserving the function’s existence and signature. This avoids altering how callers invoke `htmlPrefilter`, but eliminates the dangerous transformation that can reintroduce XSS. Upstream jQuery 3.5.0+ essentially does this by default, so this change mirrors a well-tested behavior and minimizes functional risk.

Concretely, in `vendor/jquery/jquery.js`, at the `jQuery.extend({ ... htmlPrefilter: function( html ) { ... } })` block around line 5977, replace:

```js
htmlPrefilter: function( html ) {
    return html.replace( rxhtmlTag, "<$1></$2>" );
},
```

with:

```js
htmlPrefilter: function( html ) {
    return html;
},
```

No new imports, helpers, or dependencies are required; we only adjust the implementation body of `htmlPrefilter` to stop using `rxhtmlTag`. The `rxhtmlTag` variable can remain defined to avoid touching more of the vendor file than necessary, even though it becomes unused.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
